### PR TITLE
Fix ExecBuilderTest.testFromShellScript

### DIFF
--- a/core/src/test/java/org/wildfly/extras/sunstone/api/process/ExecBuilderTest.java
+++ b/core/src/test/java/org/wildfly/extras/sunstone/api/process/ExecBuilderTest.java
@@ -257,7 +257,7 @@ public class ExecBuilderTest {
             // a more real-life example with script stored in a resource file
             result = ExecBuilder.fromShellScript(IOUtils.toString(getClass().getResourceAsStream("shell-script"), StandardCharsets.UTF_8)).exec(sshNode);
             assertEquals(0, result.getExitCode());
-            assertThat(result.getOutput(), endsWith("Found 84 dirs\n"));
+            assertThat(result.getOutput(), endsWith("Found 37 dirs\n"));
         }
     }
 

--- a/core/src/test/java/org/wildfly/extras/sunstone/api/process/shell-script
+++ b/core/src/test/java/org/wildfly/extras/sunstone/api/process/shell-script
@@ -2,7 +2,7 @@
 
 COUNT=0
 
-for F in $(find / -type d -maxdepth 2)
+for F in $(find /etc -type d -maxdepth 2)
 do
   echo $F
 


### PR DESCRIPTION
Number of subfolders in /etc should be more stable than in root.