### PR TITLE
Fixed issue #24 (leaking VMs) for all providers

### DIFF
--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/AbstractJCloudsNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/AbstractJCloudsNode.java
@@ -69,10 +69,19 @@ import com.google.common.collect.Iterables;
  *             String publicAddress = Iterables.getFirst(initialNodeMetadata.getPublicAddresses(), null);
  *             LOGGER.info("Started {} node '{}' from image {}, its public IP address is {}",
  *                     cloudProvider.getCloudProviderType().getHumanReadableName(), name, imageName, publicAddress);
- *             waitForStartPorts();
  *         } catch (RunNodesException e) {
  *             throw new RuntimeException("Unable to create " + cloudProvider.getCloudProviderType().getHumanReadableName()
  *                     + " node from template " + template, e);
+ *         }
+ *
+ *         try {
+ *             waitForStartPorts();
+ *         } catch (Exception e) {
+ *             // to avoid leaking VMs in case there is an issue when opening the ports
+ *             if (!objectProperties.getPropertyAsBoolean(Config.LEAVE_NODES_RUNNING, false)) {
+ *                 computeService.destroyNode(initialNodeMetadata.getId());
+ *             }
+ *             throw e;
  *         }
  *     }
  *

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmNode.java
@@ -79,10 +79,18 @@ public class AzureArmNode extends AbstractJCloudsNode<AzureArmCloudProvider> {
             String publicAddress = Iterables.getFirst(initialNodeMetadata.getPublicAddresses(), null);
             LOGGER.info("Started {} node '{}' from image {}, its public IP address is {}",
                     cloudProvider.getCloudProviderType().getHumanReadableName(), name, imageName, publicAddress);
-            waitForStartPorts();
         } catch (RunNodesException e) {
             throw new RuntimeException("Unable to create " + cloudProvider.getCloudProviderType().getHumanReadableName()
                     + " node from template " + template, e);
+        }
+
+        try {
+            waitForStartPorts();
+        } catch (Exception e) {
+            if (!objectProperties.getPropertyAsBoolean(Config.LEAVE_NODES_RUNNING, false)) {
+                computeService.destroyNode(initialNodeMetadata.getId());
+            }
+            throw e;
         }
     }
 

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/docker/DockerNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/docker/DockerNode.java
@@ -134,10 +134,18 @@ public class DockerNode extends AbstractJCloudsNode<DockerCloudProvider> {
             String publicAddress = Iterables.getFirst(initialNodeMetadata.getPublicAddresses(), null);
             LOGGER.info("Started {} node '{}' from image {}, its public IP address is {}",
                     cloudProvider.getCloudProviderType().getHumanReadableName(), name, imageName, publicAddress);
-            waitForStartPorts();
         } catch (RunNodesException e) {
             throw new RuntimeException("Unable to create " + cloudProvider.getCloudProviderType().getHumanReadableName()
                     + " node from template " + template, e);
+        }
+
+        try {
+            waitForStartPorts();
+        } catch (Exception e) {
+            if (!objectProperties.getPropertyAsBoolean(Config.LEAVE_NODES_RUNNING, false)) {
+                computeService.destroyNode(initialNodeMetadata.getId());
+            }
+            throw e;
         }
     }
 

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/ec2/EC2Node.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/ec2/EC2Node.java
@@ -81,10 +81,18 @@ public class EC2Node extends AbstractJCloudsNode<EC2CloudProvider> {
             String publicAddress = Iterables.getFirst(initialNodeMetadata.getPublicAddresses(), null);
             LOGGER.info("Started {} node '{}' from image {}, its public IP address is {}",
                     cloudProvider.getCloudProviderType().getHumanReadableName(), name, imageName, publicAddress);
-            waitForStartPorts();
         } catch (RunNodesException e) {
             throw new RuntimeException("Unable to create " + cloudProvider.getCloudProviderType().getHumanReadableName()
                     + " node from template " + template, e);
+        }
+
+        try {
+            waitForStartPorts();
+        } catch (Exception e) {
+            if (!objectProperties.getPropertyAsBoolean(Config.LEAVE_NODES_RUNNING, false)) {
+                computeService.destroyNode(initialNodeMetadata.getId());
+            }
+            throw e;
         }
     }
 

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
@@ -117,10 +117,18 @@ public class OpenstackNode extends AbstractJCloudsNode<OpenstackCloudProvider> {
             String publicAddress = Iterables.getFirst(initialNodeMetadata.getPublicAddresses(), null);
             LOGGER.info("Started {} node '{}' from image {}, its public IP address is {}",
                     cloudProvider.getCloudProviderType().getHumanReadableName(), name, imageName, publicAddress);
-            waitForStartPorts();
         } catch (RunNodesException e) {
             throw new RuntimeException("Unable to create " + cloudProvider.getCloudProviderType().getHumanReadableName()
                     + " node from template " + template, e);
+        }
+
+        try {
+            waitForStartPorts();
+        } catch (Exception e) {
+            if (!objectProperties.getPropertyAsBoolean(Config.LEAVE_NODES_RUNNING, false)) {
+                computeService.destroyNode(initialNodeMetadata.getId());
+            }
+            throw e;
         }
     }
 

--- a/core/src/test/java/org/wildfly/extras/sunstone/api/impl/docker/NodeLeakOnBadPortsTest.java
+++ b/core/src/test/java/org/wildfly/extras/sunstone/api/impl/docker/NodeLeakOnBadPortsTest.java
@@ -1,0 +1,35 @@
+package org.wildfly.extras.sunstone.api.impl.docker;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.extras.sunstone.api.CloudProperties;
+import org.wildfly.extras.sunstone.api.CloudProvider;
+import org.wildfly.extras.sunstone.api.PortOpeningException;
+
+/**
+ * Checks if node is correctly closed when the expected "start-up port" is not opened in given timeout.
+ */
+public class NodeLeakOnBadPortsTest {
+
+    @Test
+    public void test() {
+        CloudProperties.getInstance().reset().load(this.getClass());
+        try (DockerCloudProvider cloudProvider = (DockerCloudProvider) CloudProvider.create("provider0")) {
+            final ComputeService computeService = cloudProvider.getComputeServiceContext().getComputeService();
+            assertTrue("No node-group should be 'node-leak-test' before test", computeService.listNodes().stream()
+                    .noneMatch(cm -> "node-leak-test".equals(((NodeMetadata) cm).getGroup())));
+            try {
+                cloudProvider.createNode("node0").close();
+                Assert.fail("Port 2468 was unexpectedly opened");
+            } catch (PortOpeningException e) {
+                assertTrue("No node-group should be 'node-leak-test' after test", computeService.listNodes().stream()
+                        .noneMatch(cm -> "node-leak-test".equals(((NodeMetadata) cm).getGroup())));
+            }
+        }
+    }
+
+}

--- a/core/src/test/java/org/wildfly/extras/sunstone/api/impl/docker/NodeLeakOnBadPortsTest.properties
+++ b/core/src/test/java/org/wildfly/extras/sunstone/api/impl/docker/NodeLeakOnBadPortsTest.properties
@@ -1,0 +1,8 @@
+cloud.provider.provider0.type=docker
+cloud.provider.provider0.docker.endpoint=${provider0:http://127.0.0.1:2375/}
+
+node.node0.nodegroup=node-leak-test
+node.node0.docker.image=kwart/alpine-ext:3.2-bash
+node.node0.docker.waitForPorts=2468
+node.node0.docker.waitForPorts.timeoutSec=1
+node.node0.docker.cmd=sh,-c,while true; do sleep 30; done


### PR DESCRIPTION
Nodes are now getting closed when an exception is thrown. That same exception is re-thrown unmodified.