### PR TITLE
Refactoring and error rethrow in CloudProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   `ec2.securityGroupIds`; note that security group IDs have to be provided, not names
 - added more restrictive permissions to the temporary files created for path resources 
   with `classpath:` prefix (if the underlying OS supports configuring the permissions)
+- `CloudProperties` now throw `ResourceLoadingException` when loading properties from a
+  source that does not exist; the thrown excepion wraps its cause
 
 ## 0.8.0 (2016-08-03)
 

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/CloudProperties.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/CloudProperties.java
@@ -107,13 +107,18 @@ public final class CloudProperties {
                     properties.load(is);
                     LOGGER.debug("CloudProperties loaded from {}", path);
                 } else {
-                    LOGGER.warn("Loading CloudProperties failed, because the file {} was not found", path);
+                    String message = "Loading CloudProperties failed, because the file " + path + " was not found";
+                    LOGGER.warn(message);
+                    throw new ResourceLoadingException(message);
                 }
             } catch (IOException e) {
                 LOGGER.error("Loading CloudProperties from {} failed", path, e);
+                throw new ResourceLoadingException(e);
             }
         } else {
-            LOGGER.warn("Unable to read properties from null path");
+            String message = "Unable to read properties from null path";
+            LOGGER.warn(message);
+            throw new NullPointerException(message);
         }
         return this;
     }
@@ -130,9 +135,12 @@ public final class CloudProperties {
                 LOGGER.debug("CloudProperties loaded from given InputStream", is);
             } catch (IOException e) {
                 LOGGER.error("Loading CloudProperties from given InputStream failed", e);
+                throw new ResourceLoadingException(e);
             }
         } else {
-            LOGGER.warn("Unable to read properties from null InputStream");
+            String message = "Unable to read properties from null InputStream";
+            LOGGER.warn(message);
+            throw new NullPointerException(message);
         }
         return this;
     }
@@ -158,9 +166,12 @@ public final class CloudProperties {
                 LOGGER.debug("CloudProperties loaded from classpath resource {}", propertiesResourcePath);
             } catch (IOException e) {
                 LOGGER.error("Loading CloudProperties from given classpath resource failed", e);
+                throw new ResourceLoadingException(e);
             }
         } else {
-            LOGGER.warn("Unable to load properties for null Class");
+            String message = "Unable to load properties for null Class";
+            LOGGER.warn(message);
+            throw new NullPointerException(message);
         }
         return this;
     }

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/ResourceLoadingException.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/ResourceLoadingException.java
@@ -1,0 +1,26 @@
+package org.wildfly.extras.sunstone.api;
+
+/**
+ * Exception to be thrown when resource loading fails for any reason.
+ */
+public class ResourceLoadingException extends RuntimeException {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Constructs the exception with custom message and cause provided.
+     *
+     * @param message custom exception message
+     * @param cause the cause
+     */
+    public ResourceLoadingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ResourceLoadingException(String message) {
+        super(message);
+    }
+
+    public ResourceLoadingException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
An `IllegalStateException` is now thrown when `CloudProperties.load("i_dont_exist")` is called (any variant of `load`). There's also a bit of refactoring - `load(InputStream)` gets used in the other two variants of `load` now.