### PR TITLE
Increasing logging shloud make Coverity/FindBugs happy

### DIFF
--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/FilesUtils.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/FilesUtils.java
@@ -42,16 +42,19 @@ public final class FilesUtils {
     }
 
     /**
-     * This method sets permissions to the given file to not allow everybody to read it. Only when underlying OS allows the change.
+     * This method sets permissions to the given file to not allow everybody to read it. Only when underlying OS allows the
+     * change.
      *
      * @param file File to set permissions (must be not-{@code null})
      */
     public static void setNotWorldReadablePermissions(File file) {
-       file.setReadable(false, false);
-       file.setWritable(false, false);
-       file.setExecutable(false, false);
-       file.setReadable(true, true);
-       file.setWritable(true, true);
+        boolean permChgResult = true;
+        permChgResult &= file.setReadable(false, false);
+        permChgResult &= file.setWritable(false, false);
+        permChgResult &= file.setExecutable(false, false);
+        permChgResult &= file.setReadable(true, true);
+        permChgResult &= file.setWritable(true, true);
+        LOGGER.debug("Changing '{}' file permission to be not world-readable {}.", file, permChgResult ? "succeeded" : "failed");
     }
 
 }


### PR DESCRIPTION
Should resolve following:

```
New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)


** CID 1353456:  FindBugs: Bad practice  (FB.RV_RETURN_VALUE_IGNORED_BAD_PRACTICE)
/core/src/main/java/org/wildfly/extras/sunstone/api/impl/FilesUtils.java: 54 in org.wildfly.extras.sunstone.api.impl.FilesUtils.setNotWorldReadablePermissions(java.io.File)()


________________________________________________________________________________________________________
*** CID 1353456:  FindBugs: Bad practice  (FB.RV_RETURN_VALUE_IGNORED_BAD_PRACTICE)
/core/src/main/java/org/wildfly/extras/sunstone/api/impl/FilesUtils.java: 54 in org.wildfly.extras.sunstone.api.impl.FilesUtils.setNotWorldReadablePermissions(java.io.File)()
48          */
49         public static void setNotWorldReadablePermissions(File file) {
50            file.setReadable(false, false);
51            file.setWritable(false, false);
52            file.setExecutable(false, false);
53            file.setReadable(true, true);
>>>     CID 1353456:  FindBugs: Bad practice  (FB.RV_RETURN_VALUE_IGNORED_BAD_PRACTICE)
>>>     Another occurrence here
54            file.setWritable(true, true);
55         }
56
```