### PR TITLE
Fixes #59 - makes sudoers fix optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   in `ExecBuilder`
 - added `docker.ssh.privateKeyFile` which allows to specify path to the private key file
   which is used to connect to the instance via ssh.
+- removed automatic fixing `/etc/sudoers` file when an SSH client instance is requested from Node
+  - added `ssh.fixSudoers` Node property which enables the logic 
 
 ## 0.9.0 (2016-09-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   which is used to connect to the instance via ssh.
 - removed automatic fixing `/etc/sudoers` file when an SSH client instance is requested from Node
   - added `ssh.fixSudoers` Node property which enables the logic 
+- use public JClouds release `2.0.0`
 
 ## 0.9.0 (2016-09-06)
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ List of general `Node` properties:
 | bootScript.remotePath | Path on the Node, where the bootScript should be stored.                            | `"/tmp/onBootScript.sh"` |
 | bootScript.waitForPorts | What ports (comma separated list) to wait for **before** the executing `bootScript`. This property is not used if no `bootScript` (or `bootScript.file`) is provided. | [None. Optional.] |
 | bootScript.waitForPorts.timeoutSec | How long to wait for ports to open before the bootscript is executed (in seconds). | 60    |
+| ssh.fixSudoers   | Flag (`true`/`false`) which controls if disabling `requiretty` option is requested for `/etc/sudoers` file. | false  |
 | start.timeoutSec | How long to wait for node start (in seconds).                                            | 300               |
 | stop.timeoutSec  | How long to wait for node stop (in seconds).                                             | 300               |
 | sudo.command     | Sudo command to be used for `ExecBuilder` executions when `withSudo()` is used.          | `sudo -S`         |

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/AbstractJCloudsNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/AbstractJCloudsNode.java
@@ -354,10 +354,7 @@ public abstract class AbstractJCloudsNode<CP extends AbstractJCloudsCloudProvide
 
     @Override
     public org.wildfly.extras.sunstone.api.ssh.SshClient ssh() throws InterruptedException {
-        return new JCloudsSshClient(getName(), () -> {
-            NodeMetadata nodeMetadata = getFreshNodeMetadata();
-            return cloudProvider.getComputeServiceContext().utils().sshForNode().apply(nodeMetadata);
-        });
+        return new JCloudsSshClient(this);
     }
 
     /**

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
@@ -137,6 +137,8 @@ public final class Config {
             public static final String START_TIMEOUT_SEC = "start.timeoutSec";
 
             public static final String SUDO_COMMAND = "sudo.command";
+
+            public static final String SSH_FIX_SUDOERS = "ssh.fixSudoers";
         }
 
         /**

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.org.wildfly.core>2.2.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.4.0</version.org.wildfly.extras.creaper>
 
-        <version.jclouds>2.0.0-SNAPSHOT</version.jclouds>
+        <version.jclouds>2.0.0</version.jclouds>
         <version.surefire>2.19.1</version.surefire>
         <version.commons.lang>3.4</version.commons.lang>
         <version.commons.io>2.4</version.commons.io>


### PR DESCRIPTION
Fixes #59.

Automatic fixing of `/etc/sudoers` file was removed and the workaround can be enabled for Node by setting property `ssh.fixSudoers`.

The second commit upgrades the JClouds to version `2.0.0` final.