### PR TITLE
Fixed testsuite failures on JDK9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - added `ExecBuilderFactory` that allows to create preconfigured `ExecBuilder`
 - added `templateTo` property on nodes to allow inverted creation of copies of nodes
 - fixed two property names starting with `clouds` and not `sunstone`
+- fixed issues with the testsuite on JDK 9+
+- added `openstack.networks` to the configurable options for OpenStack provider
 
 ## 1.0.0 (2017-01-06)
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -104,5 +104,19 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- JAXB -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
@@ -246,6 +246,7 @@ public final class Config {
             public static final String IMAGE_ID = "openstack.image.id";
             public static final String KEY_PAIR = "openstack.keyPair";
             public static final String SECURITY_GROUPS = "openstack.securityGroups";
+            public static final String NETWORKS = "openstack.networks";
             public static final String INBOUND_PORTS = "openstack.inboundPorts";
             public static final String SSH_PRIVATE_KEY = "openstack.ssh.privateKey";
             public static final String SSH_PRIVATE_KEY_FILE = "openstack.ssh.privateKeyFile";

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/docker/DockerNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/docker/DockerNode.java
@@ -156,10 +156,10 @@ public class DockerNode extends AbstractJCloudsNode<DockerCloudProvider> {
                     });
         }
 
-        Map<String, Object> exposedPorts = null;
+        Map<String, Object> exposedPorts;
         final int[] inboundPorts = Pattern.compile(",")
-                .splitAsStream(objectProperties.getProperty(Config.Node.Docker.INBOUND_PORTS, "")).mapToInt(Integer::parseInt)
-                .toArray();
+                .splitAsStream(objectProperties.getProperty(Config.Node.Docker.INBOUND_PORTS, ""))
+                .filter(match -> !match.isEmpty()).mapToInt(Integer::parseInt).toArray();
         if (inboundPorts.length > 0) {
             templateOptions.inboundPorts(inboundPorts);
             exposedPorts = Maps.newHashMap();

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
@@ -147,6 +147,11 @@ public class OpenstackNode extends AbstractJCloudsNode<OpenstackCloudProvider> {
             templateOptions.securityGroups(securityGroups.split(","));
         }
 
+        final String networks = objectProperties.getProperty(Config.Node.Openstack.NETWORKS);
+        if (!Strings.isNullOrEmpty(networks)) {
+            templateOptions.networks(networks.split(","));
+        }
+
         byte[] userData = null;
         final String userDataStr = objectProperties.getProperty(Config.Node.Openstack.USER_DATA);
         final Path userDataFile = objectProperties.getPropertyAsPath(Config.Node.Openstack.USER_DATA_FILE, null);

--- a/core/src/test/java/org/wildfly/extras/sunstone/tests/openstack/OpenstackTest.properties
+++ b/core/src/test/java/org/wildfly/extras/sunstone/tests/openstack/OpenstackTest.properties
@@ -15,6 +15,7 @@ node.mynode.openstack.waitForPorts=22
 node.mynode.openstack.waitForPorts.timeoutSec=300
 node.mynode.openstack.keyPair=${openstack.keypair}
 node.mynode.openstack.securityGroups=allow-all
+node.mynode.openstack.networks=${openstack.networks}
 node.mynode.openstack.floatingIpPools=${openstack.floatingIpPools:}
 
 node.othernode.template=mynode

--- a/openstack-README.md
+++ b/openstack-README.md
@@ -64,22 +64,23 @@ List of OpenStack `CloudProvider` properties:
 
 List of OpenStack `Node` properties:
 
-| Property name               | Description                                                       | Default value                      |
-|:----------------------------|:------------------------------------------------------------------|:-----------------------------------|
-| nodegroup                   | Name of the node group for this node. Default value should typically be satisfactory. | The `nodegroup` value from the cloud provider. |
-| openstack.instance.type     | Instance type for the node (Flavor). This defines the computing/networking/... capabilities of the node. | [None. Mandatory.] |
-| openstack.image             | Name of the image for the node. If ambiguous or missing, `openstack.image.id` will be used. | [None. Mandatory. (Well techinically, it's optional, but it's recommended to treat is as mandatory.)] |
-| openstack.image.id          | ID of the image for the node. Used when `openstack.image` is ambiguous or missing. | [None. Mandatory when `openstack.image` is missing or ambiguous.] |
-| openstack.bootScript        | Allows you to specify a script that is to be run on boot. The script is run with `sudo`. | [None. Optional.] |
-| openstack.bootScript.file   | As `openstack.bootScript`, but allows you to specify a path to a file that contains the script. Only one of `openstack.bootScript` and `openstack.bootScript.file` can be specified at a time. | [None. Optional.] |
-| openstack.floatingIpPools   | Comma separated list of floating IP pool names. If the value is not provided, then all available pool names are used. | [None. Optional.] |
-| openstack.keyPair           | The key pair name (for public key) to be imported into this instance as an `authorized_key`. You can import a public key in the OpenStack dashboard. | [None. Optional.] |
-| openstack.inboundPorts      | Comma separated list of ports that can be used to access the instance. You will usually require at least port 22 for ssh access. | [None. Optional.] |
-| openstack.region            | OpenStack Location/Region name. If there is only one region, then the property config is optional. | [None. Mandatory when more regions.] |
-| openstack.securityGroups    | The comma separated security group names for the instance.        | [None. Optional.] |
-| openstack.ssh.user          | The user name for accessing the instance via SSH. See [http://docs.openstack.org/image-guide/obtain-images.html](http://docs.openstack.org/image-guide/obtain-images.html) for typical user names for images of various operating systems. | [None. Optional.] |
-| openstack.ssh.password      | Overrides the user password for accessing the instance.           | [None. Optional. One of `openstack.ssh.password`, `openstack.ssh.privateKey` or `openstack.ssh.privateKeyFile` should be set.] |
-| openstack.ssh.privateKey    | PEM encoded PKCS#8 private key which should be used to connect to the instance. | [None. Optional. One of `openstack.ssh.password`, `openstack.ssh.privateKey` or `openstack.ssh.privateKeyFile` should be set.] |
+| Property name                | Description                                                       | Default value                      |
+|:-----------------------------|:------------------------------------------------------------------|:-----------------------------------|
+| nodegroup                    | Name of the node group for this node. Default value should typically be satisfactory. | The `nodegroup` value from the cloud provider. |
+| openstack.instance.type      | Instance type for the node (Flavor). This defines the computing/networking/... capabilities of the node. | [None. Mandatory.] |
+| openstack.image              | Name of the image for the node. If ambiguous or missing, `openstack.image.id` will be used. | [None. Mandatory. (Well techinically, it's optional, but it's recommended to treat is as mandatory.)] |
+| openstack.image.id           | ID of the image for the node. Used when `openstack.image` is ambiguous or missing. | [None. Mandatory when `openstack.image` is missing or ambiguous.] |
+| openstack.bootScript         | Allows you to specify a script that is to be run on boot. The script is run with `sudo`. | [None. Optional.] |
+| openstack.bootScript.file    | As `openstack.bootScript`, but allows you to specify a path to a file that contains the script. Only one of `openstack.bootScript` and `openstack.bootScript.file` can be specified at a time. | [None. Optional.] |
+| openstack.floatingIpPools    | Comma separated list of floating IP pool names. If the value is not provided, then all available pool names are used. | [None. Optional.] |
+| openstack.keyPair            | The key pair name (for public key) to be imported into this instance as an `authorized_key`. You can import a public key in the OpenStack dashboard. | [None. Optional.] |
+| openstack.inboundPorts       | Comma separated list of ports that can be used to access the instance. You will usually require at least port 22 for ssh access. | [None. Optional.] |
+| openstack.region             | OpenStack Location/Region name. If there is only one region, then the property config is optional. | [None. Mandatory when more regions.] |
+| openstack.securityGroups     | The comma separated security group names for the instance.        | [None. Optional.] |
+| openstack.networks           | The comma separated list of networks for the instance. Expects network UUIDs (not human-readable names).        | [None. Optional.] |
+| openstack.ssh.user           | The user name for accessing the instance via SSH. See [http://docs.openstack.org/image-guide/obtain-images.html](http://docs.openstack.org/image-guide/obtain-images.html) for typical user names for images of various operating systems. | [None. Optional.] |
+| openstack.ssh.password       | Overrides the user password for accessing the instance.           | [None. Optional. One of `openstack.ssh.password`, `openstack.ssh.privateKey` or `openstack.ssh.privateKeyFile` should be set.] |
+| openstack.ssh.privateKey     | PEM encoded PKCS#8 private key which should be used to connect to the instance. | [None. Optional. One of `openstack.ssh.password`, `openstack.ssh.privateKey` or `openstack.ssh.privateKeyFile` should be set.] |
 | openstack.ssh.privateKeyFile | The path to the private key file which should be used to connect to the instance. If special value `default` is used, then private key is loaded from `~/.ssh/id_rsa`. This property is only used when the `openstack.ssh.privateKey` property is empty.| [None. Optional. One of `openstack.ssh.password`, `openstack.ssh.privateKey` or `openstack.ssh.privateKeyFile` should be set.] |
-| openstack.userData          | User data in a string. Takes precedence over `openstack.userData.file`. | [None. Optional.] |
-| openstack.userData.file     | Path to file with user data.                                      | [None. Optional.] |
+| openstack.userData           | User data in a string. Takes precedence over `openstack.userData.file`. | [None. Optional.] |
+| openstack.userData.file      | Path to file with user data.                                      | [None. Optional.] |

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         </developer>
         <developer>
             <id>LittleJohnII</id>
-            <name>Richard Janik</name>
+            <name>Richard Janík</name>
             <url>https://github.com/LittleJohnII/</url>
         </developer>
         <developer>
@@ -53,6 +53,7 @@
         <version.guava>19.0</version.guava>
         <version.slf4j>1.7.21</version.slf4j>
         <version.logback>1.0.13</version.logback>
+        <version.jaxb>2.3.0</version.jaxb>
 
         <!-- Checkstyle configuration -->
         <version.checkstyle.plugin>2.17</version.checkstyle.plugin>
@@ -372,6 +373,23 @@
                 <artifactId>java-hamcrest</artifactId>
                 <version>${version.hamcrest}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- JAXB dependencies, need to be explicitly specified since Java 9 -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.jaxb}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${version.jaxb}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${version.jaxb}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
* $subj - related to missing JAXB dependency
* added the ability to specify `openstack.networks` (needed for OpenStack instances with more networks)
* fixed NPE in DockerNode on JDK9+