### PR TITLE
Upgraded JClouds dependency to 2.1.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,7 +61,7 @@
             <artifactId>azurecompute</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.jclouds.labs</groupId>
+            <groupId>org.apache.jclouds.provider</groupId>
             <artifactId>azurecompute-arm</artifactId>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmCloudProvider.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmCloudProvider.java
@@ -44,10 +44,7 @@ public class AzureArmCloudProvider extends AbstractJCloudsCloudProvider {
         String publishers = objectProperties.getProperty(Config.CloudProvider.AzureArm.PUBLISHERS, "Canonical,RedHat");
 
         Properties defaultPropertyOverrides = new Properties();
-        // there's no constant for this :-(
-        defaultPropertyOverrides.setProperty("oauth.endpoint", "https://login.microsoftonline.com/" + tenantId + "/oauth2/token");
-        // 100 GB by default is way too much; maybe make this configurable?
-        defaultPropertyOverrides.setProperty(AzureComputeProperties.DEFAULT_DATADISKSIZE, "20");
+        defaultPropertyOverrides.setProperty(AzureArmPropertiesUnsupported.OAUTH_ENDPOINT, "https://login.microsoftonline.com/" + tenantId + "/oauth2/token");
         defaultPropertyOverrides.setProperty(AzureComputeProperties.IMAGE_PUBLISHERS, publishers);
         // listing all images is very expensive, so they should be cached for a long time
         // unfortunately, the default is 1 minute, which can never be sufficient; we use 5 hours here

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmPropertiesUnsupported.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/azurearm/AzureArmPropertiesUnsupported.java
@@ -1,0 +1,5 @@
+package org.wildfly.extras.sunstone.api.impl.azurearm;
+
+class AzureArmPropertiesUnsupported {
+    static final String OAUTH_ENDPOINT = "oauth.endpoint";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.org.wildfly.core>2.2.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.4.0</version.org.wildfly.extras.creaper>
 
-        <version.jclouds>2.0.0</version.jclouds>
+        <version.jclouds>2.1.0</version.jclouds>
         <version.surefire>2.19.1</version.surefire>
         <version.commons.lang>3.4</version.commons.lang>
         <version.commons.io>2.4</version.commons.io>
@@ -299,6 +299,11 @@
             <dependency>
                 <groupId>org.apache.jclouds.api</groupId>
                 <artifactId>byon</artifactId>
+                <version>${version.jclouds}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jclouds.provider</groupId>
+                <artifactId>azurecompute-arm</artifactId>
                 <version>${version.jclouds}</version>
             </dependency>
 


### PR DESCRIPTION
Fixes #71 

Note: `DEFAULT_DATADISKSIZE` has been removed in the ARM provider between versions 2.0 and 2.1, because it has never actually been used before - yes, the constant was present in JClouds Labs, but the property it represents was never queried when spinning up VMs.