### PR TITLE
Adapted for Openstack Keystone V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 1.2.0 (not yet released)
+## 1.1.1 (not yet released)
+- added `openstack.projectName`, `openstack.projectDomainId` and `openstack.userDomainName` to the configurable options for OpenStack provider, in order to authenticate when using Keystone v3 API
+- added `openstack.autoAssignFloatingIp` to the configurable options for OpenStack provider
 
 ## 1.1.0 (2019-01-09)
 - added `ExecBuilder#exec` method with configurable timeout

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
@@ -110,6 +110,9 @@ public final class Config {
             public static final String ENDPOINT = "openstack.endpoint";
             public static final String USERNAME = "openstack.username";
             public static final String PASSWORD = "openstack.password";
+            public static final String PROJECT_NAME = "openstack.projectName";              // Keystone V3
+            public static final String PROJECT_DOMAIN_ID = "openstack.projectDomainId";     // Keystone V3
+            public static final String USER_DOMAIN_NAME = "openstack.userDomainName";       // Keystone V3
         }
 
         /**
@@ -253,6 +256,7 @@ public final class Config {
             public static final String USER_DATA = "openstack.userData";
             public static final String USER_DATA_FILE = "openstack.userData.file";
             public static final String FLOATING_IP_POOLS = "openstack.floatingIpPools";
+            public static final String AUTO_ASSIGN_FLOATING_IP = "openstack.autoAssignFloatingIp";
         }
 
         /**

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackCloudProvider.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackCloudProvider.java
@@ -1,28 +1,33 @@
 package org.wildfly.extras.sunstone.api.impl.openstack;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
+import com.google.common.base.Strings;
+import com.google.inject.Module;
+import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.jclouds.openstack.keystone.config.KeystoneProperties;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.slf4j.Logger;
 import org.wildfly.extras.sunstone.api.CloudProviderType;
 import org.wildfly.extras.sunstone.api.impl.AbstractJCloudsCloudProvider;
 import org.wildfly.extras.sunstone.api.impl.Config;
 import org.wildfly.extras.sunstone.api.impl.DynamicSshClientModule;
 import org.wildfly.extras.sunstone.api.impl.ObjectProperties;
 import org.wildfly.extras.sunstone.api.impl.SocketFinderOnlyPublicInterfacesModule;
+import org.wildfly.extras.sunstone.api.impl.SunstoneCoreLogger;
 import org.wildfly.extras.sunstone.api.jclouds.JCloudsNode;
 
-import com.google.common.base.Strings;
-import com.google.inject.Module;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * Openstack implementation of CloudProvider. This implementation uses JClouds internally.
  */
 public final class OpenstackCloudProvider extends AbstractJCloudsCloudProvider {
+    private static final Logger LOGGER = SunstoneCoreLogger.DEFAULT;
+
     public OpenstackCloudProvider(String providerName, Map<String, String> overrideMap) {
         super(providerName, CloudProviderType.OPENSTACK, overrideMap, OpenstackCloudProvider::createContextBuilder);
     }
@@ -37,18 +42,79 @@ public final class OpenstackCloudProvider extends AbstractJCloudsCloudProvider {
         overrides.setProperty("jclouds.ssh.retry-auth", Boolean.FALSE.toString());
         overrides.setProperty("jclouds.ssh.max-retries", Integer.toString(1));
 
-        ContextBuilder contextBuilder = ContextBuilder.newBuilder("openstack-nova");
         String endpoint = objectProperties.getProperty(Config.CloudProvider.Openstack.ENDPOINT);
-        if (!Strings.isNullOrEmpty(endpoint)) {
-            contextBuilder.endpoint(endpoint);
+        if (!Strings.isNullOrEmpty(endpoint) && endpoint.contains("/v3")) {
+            // ===================================================
+            // Keystone V3
+            // ===================================================
+            LOGGER.info("Using {} version 3", KeystoneProperties.KEYSTONE_VERSION);
+            overrides.put(KeystoneProperties.KEYSTONE_VERSION, "3");
+            // Ignore SSL
+            overrides.setProperty(Constants.PROPERTY_RELAX_HOSTNAME, "true");
+            overrides.setProperty(Constants.PROPERTY_TRUST_ALL_CERTS, "true");
+
+            // ===================================================
+            // Using "Project-scoped" keystone v3 authentication:
+            // https://jclouds.apache.org/guides/openstack/
+            // ===================================================
+
+            // Project name
+            String projectName = objectProperties.getProperty(Config.CloudProvider.Openstack.PROJECT_NAME);
+            if (projectName == null) {
+                throw new IllegalStateException(String.format("Property '%s' not set", Config.CloudProvider.Openstack.PROJECT_NAME));
+            } else {
+                overrides.setProperty(KeystoneProperties.SCOPE, String.format("project:%s", projectName));
+            }
+
+            // Domain ID
+            String projectDomainId = objectProperties.getProperty(Config.CloudProvider.Openstack.PROJECT_DOMAIN_ID);
+            if (projectDomainId == null) {
+                LOGGER.warn("Property {} not set", Config.CloudProvider.Openstack.PROJECT_DOMAIN_ID);
+            } else {
+                overrides.setProperty(KeystoneProperties.PROJECT_DOMAIN_ID, projectDomainId);
+            }
+        } else {
+            // ===================================================
+            // Keystone V2
+            // ===================================================
+            LOGGER.info("Using {} version 2", KeystoneProperties.KEYSTONE_VERSION);
         }
-        contextBuilder
-                .credentials(
-                        objectProperties.getProperty(Config.CloudProvider.Openstack.USERNAME),
-                        objectProperties.getProperty(Config.CloudProvider.Openstack.PASSWORD)
-                )
-                .overrides(overrides)
-                .modules(modules);
+
+        ContextBuilder contextBuilder = null;
+
+        if (!Strings.isNullOrEmpty(endpoint) && endpoint.contains("/v3")) {
+            // ===================================================
+            // Keystone V3
+            // ===================================================
+            String userDomainName = objectProperties.getProperty(Config.CloudProvider.Openstack.USER_DOMAIN_NAME);
+            if (userDomainName == null) {
+                throw new IllegalStateException(String.format("Property '%s' not set", Config.CloudProvider.Openstack.USER_DOMAIN_NAME));
+            }
+            contextBuilder = ContextBuilder.newBuilder("openstack-nova")
+                    .endpoint(endpoint)
+                    .modules(modules)
+                    .overrides(overrides)
+                    .credentials(
+                            // env("OS_USER_DOMAIN_NAME") + ":" + env("OS_USERNAME"), env("OS_PASSWORD")
+                            String.format("%s:%s", userDomainName, objectProperties.getProperty(Config.CloudProvider.Openstack.USERNAME)),
+                            objectProperties.getProperty(Config.CloudProvider.Openstack.PASSWORD)
+                    );
+        } else {
+            // ===================================================
+            // Keystone V2
+            // ===================================================
+            contextBuilder = ContextBuilder.newBuilder("openstack-nova");
+            if (!Strings.isNullOrEmpty(endpoint)) {
+                contextBuilder.endpoint(endpoint);
+            }
+            contextBuilder
+                    .credentials(
+                            objectProperties.getProperty(Config.CloudProvider.Openstack.USERNAME),
+                            objectProperties.getProperty(Config.CloudProvider.Openstack.PASSWORD)
+                    )
+                    .overrides(overrides)
+                    .modules(modules);
+        }
 
         return contextBuilder;
     }

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/openstack/OpenstackNode.java
@@ -118,7 +118,13 @@ public class OpenstackNode extends AbstractJCloudsNode<OpenstackCloudProvider> {
     }
 
     private static NovaTemplateOptions buildTemplateOptions(ObjectProperties objectProperties) {
-        NovaTemplateOptions templateOptions = NovaTemplateOptions.Builder.autoAssignFloatingIp(true);
+        boolean autoAssignFloatingIp = true;
+        final String autoAssignFloatingIpStr = objectProperties.getProperty(Config.Node.Openstack.AUTO_ASSIGN_FLOATING_IP);
+        if (!Strings.isNullOrEmpty(autoAssignFloatingIpStr)) {
+            autoAssignFloatingIp = Boolean.parseBoolean(autoAssignFloatingIpStr);
+        }
+
+        NovaTemplateOptions templateOptions = NovaTemplateOptions.Builder.autoAssignFloatingIp(autoAssignFloatingIp);
 
         final String floatingIpPoolNames = objectProperties.getProperty(Config.Node.Openstack.FLOATING_IP_POOLS);
         if (!Strings.isNullOrEmpty(floatingIpPoolNames)) {

--- a/openstack-README.md
+++ b/openstack-README.md
@@ -59,6 +59,9 @@ List of OpenStack `CloudProvider` properties:
 | openstack.endpoint     | A specific endpoint for connecting within the given region.       | [None. Mandatory.]                 |
 | openstack.username     | The username in form `[tenant]:[user]` for your user.             | [None. Mandatory.]                 |
 | openstack.password     | The password for your user.                                       | [None. Mandatory.]                 |
+| openstack.projectName  | The project name (OS_PROJECT_NAME in OpenStack RC File)           | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
+| openstack.projectDomainId | The project domain ID (OS_PROJECT_DOMAIN_ID in OpenStack RC File) | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
+| openstack.userDomainName | The user domain name (OS_USER_DOMAIN_NAME in OpenStack RC File) | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
 
 ### Node
 
@@ -73,6 +76,7 @@ List of OpenStack `Node` properties:
 | openstack.bootScript         | Allows you to specify a script that is to be run on boot. The script is run with `sudo`. | [None. Optional.] |
 | openstack.bootScript.file    | As `openstack.bootScript`, but allows you to specify a path to a file that contains the script. Only one of `openstack.bootScript` and `openstack.bootScript.file` can be specified at a time. | [None. Optional.] |
 | openstack.floatingIpPools    | Comma separated list of floating IP pool names. If the value is not provided, then all available pool names are used. | [None. Optional.] |
+| openstack.autoAssignFloatingIp | Automatic Floating Ip assignation (if set to `false` disables Floating Ip assignation also when `openstack.floatingIpPools` is set) | `true` |
 | openstack.keyPair            | The key pair name (for public key) to be imported into this instance as an `authorized_key`. You can import a public key in the OpenStack dashboard. | [None. Optional.] |
 | openstack.inboundPorts       | Comma separated list of ports that can be used to access the instance. You will usually require at least port 22 for ssh access. | [None. Optional.] |
 | openstack.region             | OpenStack Location/Region name. If there is only one region, then the property config is optional. | [None. Mandatory when more regions.] |

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.org.wildfly.core>2.2.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.4.0</version.org.wildfly.extras.creaper>
 
-        <version.jclouds>2.1.0</version.jclouds>
+        <version.jclouds>2.1.1</version.jclouds>
         <version.surefire>2.19.1</version.surefire>
         <version.commons.lang>3.4</version.commons.lang>
         <version.commons.io>2.4</version.commons.io>


### PR DESCRIPTION
Openstack Keystone V3 uses new parameters for authentication and a different API:

- cloud.provider.myprovider.openstack.projectName=...
- cloud.provider.myprovider.openstack.projectDomainId=...
- cloud.provider.myprovider.openstack.userDomainName=...