### PR TITLE
added openstack.socketFinderAllowedInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.2.1 (not yet released)
+- added `openstack.socketFinderAllowedInterfaces` to the configurable options for OpenStack provider
 
 ## 1.2.0 (2019-03-05)
 - added `openstack.projectName`, `openstack.projectDomainId` and `openstack.userDomainName` to the configurable options for OpenStack provider, in order to authenticate when using Keystone v3 API

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/Config.java
@@ -113,6 +113,7 @@ public final class Config {
             public static final String PROJECT_NAME = "openstack.projectName";              // Keystone V3
             public static final String PROJECT_DOMAIN_ID = "openstack.projectDomainId";     // Keystone V3
             public static final String USER_DOMAIN_NAME = "openstack.userDomainName";       // Keystone V3
+            public static final String SOCKET_FINDER_ALLOWED_INTERFACES = "openstack.socketFinderAllowedInterfaces";
         }
 
         /**

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/SocketFinderAllInterfacesModule.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/SocketFinderAllInterfacesModule.java
@@ -1,0 +1,14 @@
+package org.wildfly.extras.sunstone.api.impl;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import org.jclouds.compute.config.ComputeServiceProperties;
+
+public final class SocketFinderAllInterfacesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bindConstant()
+                .annotatedWith(Names.named(ComputeServiceProperties.SOCKET_FINDER_ALLOWED_INTERFACES))
+                .to("ALL");
+    }
+}

--- a/core/src/main/java/org/wildfly/extras/sunstone/api/impl/SocketFinderOnlyPrivateInterfacesModule.java
+++ b/core/src/main/java/org/wildfly/extras/sunstone/api/impl/SocketFinderOnlyPrivateInterfacesModule.java
@@ -1,0 +1,14 @@
+package org.wildfly.extras.sunstone.api.impl;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import org.jclouds.compute.config.ComputeServiceProperties;
+
+public final class SocketFinderOnlyPrivateInterfacesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bindConstant()
+                .annotatedWith(Names.named(ComputeServiceProperties.SOCKET_FINDER_ALLOWED_INTERFACES))
+                .to("PRIVATE");
+    }
+}

--- a/openstack-README.md
+++ b/openstack-README.md
@@ -62,6 +62,7 @@ List of OpenStack `CloudProvider` properties:
 | openstack.projectName  | The project name (OS_PROJECT_NAME in OpenStack RC File)           | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
 | openstack.projectDomainId | The project domain ID (OS_PROJECT_DOMAIN_ID in OpenStack RC File) | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
 | openstack.userDomainName | The user domain name (OS_USER_DOMAIN_NAME in OpenStack RC File) | [None. Mandatory when using Keystone v3 (e.g. `cloud.provider.myprovider.openstack.endpoint=http://openstack.example.com:5000/v3`)] |
+| openstack.socketFinderAllowedInterfaces | What IPs are to be checked for ports listed in `waitForPorts`: PUBLIC,PRIVATE,ALL | `PUBLIC` (e.g. `cloud.provider.myprovider.openstack.socketFinderAllowedInterfaces=PRIVATE`)] |
 
 ### Node
 


### PR DESCRIPTION
added openstack.socketFinderAllowedInterfac to the configurable opt…ions for OpenStack provider: this was a missing option and before the waitForPorts option was forced to look only at public IPs 