### PR TITLE
[#201] Add option to keep failing deployments

### DIFF
--- a/azure/src/main/java/sunstone/azure/impl/AzureArmTemplateCloudDeploymentManager.java
+++ b/azure/src/main/java/sunstone/azure/impl/AzureArmTemplateCloudDeploymentManager.java
@@ -13,6 +13,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.slf4j.Logger;
+import sunstone.core.CoreConfig;
 import sunstone.core.TimeoutUtils;
 
 import java.io.IOException;
@@ -92,7 +93,13 @@ class AzureArmTemplateCloudDeploymentManager {
         if (pollStatus != LongRunningOperationStatus.SUCCESSFULLY_COMPLETED) {
             LOGGER.error("Azure deployment from template {} in \"{}\" group failed", deploymentName, group);
             AzureUtils.downloadResourceGroupLogs(armManager, group);
-            undeploy(group);
+            boolean keepOnFailure = getValue(CoreConfig.KEEP_FAILED_DEPLOY, false);
+            if (keepOnFailure) {
+                LOGGER.debug("Resource group {} is preserved due to {}", group, CoreConfig.KEEP_FAILED_DEPLOY);
+            } else {
+                undeploy(group);
+            }
+
             throw new RuntimeException("Deployment failed for group:" + group);
         }
 

--- a/core/src/main/java/sunstone/core/CoreConfig.java
+++ b/core/src/main/java/sunstone/core/CoreConfig.java
@@ -4,4 +4,5 @@ package sunstone.core;
 public class CoreConfig {
 
     public static final String TIMEOUT_FACTOR = "sunstone.timeout.factor";
+    public static final String KEEP_FAILED_DEPLOY = "sunstone.fail.keepFailedDeploy";
 }


### PR DESCRIPTION
keep failing deployment resources for AWS/Azure when `sunstone.fail.keepFailedDeploy` property is specified.

I have experimented in keeping resources for failing tests, but it doesn't seem viable. The closables would have to be ignored in `AfterAll` method, but results are not available there, I can only check for throwed exceptions (ctx.getExecutionException()). But even this solution would also keep resources for passing tests

contributes to #201 
